### PR TITLE
fix: 防止获取标签属性panic

### DIFF
--- a/xss.go
+++ b/xss.go
@@ -62,6 +62,7 @@ type AttrResult struct {
 	Closing bool
 }
 
+// GetAttrs 获取标签属性
 func GetAttrs(html string) AttrResult {
 	i := spaceIndex(html)
 	if i == -1 {
@@ -71,8 +72,11 @@ func GetAttrs(html string) AttrResult {
 		}
 	}
 	html = strings.TrimSpace(html[i+1 : len(html)-1])
-
-	isClosing := html[len(html)-1] == '/'
+	
+	var isClosing = false
+	if len(html) >= 0 {
+		isClosing = html[len(html)-1] == '/'
+	}
 
 	if isClosing {
 		html = strings.TrimSpace(html[0 : len(html)-1])

--- a/xss.go
+++ b/xss.go
@@ -72,9 +72,9 @@ func GetAttrs(html string) AttrResult {
 		}
 	}
 	html = strings.TrimSpace(html[i+1 : len(html)-1])
-	
+
 	var isClosing = false
-	if len(html) >= 0 {
+	if len(html) > 0 {
 		isClosing = html[len(html)-1] == '/'
 	}
 

--- a/xss_test.go
+++ b/xss_test.go
@@ -1329,6 +1329,17 @@ func TestOnIgnoreTagAttr(t *testing.T) {
 	}
 }
 
+// TestOnIgnoreWhiteListTagNullAttr 测试忽略tag 空属性
+func TestOnIgnoreWhiteListTagNullAttr(t *testing.T) {
+	source := "<a    >bb</a>"
+
+	html := FilterXSS(source, XssOption{WhiteList: GetDefaultWhiteList()})
+
+	if html != "<a>bb</a>" {
+		t.Errorf("TestOnIgnoreWhiteListTagNullAttr error")
+	}
+}
+
 func TestOnIgnoreTagAttrWithReturn(t *testing.T) {
 	source := "<a href=\"#\" target=\"_blank\" checked data-a=\"b\">hi</a href=\"d\">"
 


### PR DESCRIPTION
防止获取标签属性时panic，html为外部恶意输入，可以构造类似于\<a&nbsp;&nbsp;&nbsp;\>场景会造成数组越界panic